### PR TITLE
[FIX] Removed Unnecessary Newline Entry

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -64,7 +64,7 @@ This report, \thesistitle, is submitted in partial fulfillment of the requiremen
 \item[\tiny{$\blacksquare$}] I have acknowledged all main sources of help.
  
 \item[\tiny{$\blacksquare$}] Where the thesis is based on work done by myself jointly with others, I have made clear exactly what was done by others and what I have contributed myself.
-\\
+
 \end{itemize}
  
  


### PR DESCRIPTION
Unnecessary newline characters creates a warning in Overleaf, removing this newline doesn't cause any further issues or knock on effects so take it as a fix.

NOTE: This probably needs to be applied to all templates.